### PR TITLE
Added Pure Data receiver patch example.

### DIFF
--- a/receiver.pd
+++ b/receiver.pd
@@ -1,0 +1,33 @@
+#N canvas 893 309 450 300 10;
+#X obj 17 11 netreceive -u -b 7475;
+#X obj 17 33 oscparse;
+#X obj 17 137 route button1 button2 button3 dial1 dial2;
+#X obj 214 225 hsl 128 32 0 1 0 0 empty empty empty -2 -8 0 10 -262144
+-1 -1 0 1;
+#X obj 17 55 list trim;
+#X obj 17 159 route press;
+#X obj 17 225 tgl 32 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X obj 65 182 route press;
+#X obj 65 225 tgl 32 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X obj 114 158 route press;
+#X obj 114 225 tgl 32 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X obj 17 77 t a a;
+#X obj 44 99 print;
+#X obj 214 181 hsl 128 32 0 1 0 0 empty empty empty -2 -8 0 10 -262144
+-1 -1 0 1;
+#X connect 0 0 1 0;
+#X connect 1 0 4 0;
+#X connect 2 0 5 0;
+#X connect 2 1 7 0;
+#X connect 2 2 9 0;
+#X connect 2 3 3 0;
+#X connect 2 4 13 0;
+#X connect 4 0 11 0;
+#X connect 5 0 6 0;
+#X connect 7 0 8 0;
+#X connect 9 0 10 0;
+#X connect 11 0 2 0;
+#X connect 11 1 12 0;


### PR DESCRIPTION
You can test this by using [Pure Data](https://pure-data.info/) to open receiver.patch and run the default example.